### PR TITLE
Only deploy if Dockerfile changed

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
     - main
-    paths:
-    - Dockerfile
+    paths-ignore:
+    - '!Dockerfile'
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
     - main
-    paths-ignore:
-    - '!Dockerfile'
+    paths:
+    - 'Dockerfile'
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - main
+    paths:
+    - Dockerfile
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -72,13 +72,14 @@ jobs:
       run: docker build . --file Dockerfile --tag boss:latest
     - name: Test shell scripts
       run: |
+        export PATH=$pwd/scripts:$PATH
         mkdir workarea/Yapp
         cd workarea/Yapp
-        ../../scripts/initboss.sh
+        initboss.sh
         cd ../TestRelease/TestRelease*/cmt
-        ../../../../scripts/cmt.sh clean
-        ../../../../scripts/cmt.sh config
-        ../../../../scripts/cmt.sh make
+        cmt.sh clean
+        cmt.sh config
+        cmt.sh make
         cd ../run
-        ../../../../scripts/boss.exe.sh ./jobOptions_sim.txt
-        ../../../../scripts/stopboss.sh
+        boss.exe.sh ./jobOptions_sim.txt
+        stopboss.sh

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -61,3 +61,24 @@ jobs:
           cmt clean
           cmt config
           cmt make
+
+  build-and-test-scripts:
+    needs: [lint-dockerfile, lint-shellscripts]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag bossdocker:latest
+    - name: Test shell scripts
+      run: |
+        mkdir workarea/Yapp
+        cd workarea/Yapp
+        ../../scripts/initboss.sh
+        cd ../TestRelease/TestRelease*/cmt
+        ../../../../scripts/cmt.sh clean
+        ../../../../scripts/cmt.sh config
+        ../../../../scripts/cmt.sh make
+        cd ../run
+        ../../../../scripts/boss.exe.sh ./jobOptions_sim.txt
+        ../../../../scripts/stopboss.sh

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag bossdocker:latest
+      run: docker build . --file Dockerfile --tag boss:latest
     - name: Test shell scripts
       run: |
         mkdir workarea/Yapp


### PR DESCRIPTION
Deploying to Dockerhub and Azure anytime anything in the repo changes is a waste of ressources. Instead, deploy-image.yml now only runs if the Dockerfile itself and therefore the image has changed.