### PR TITLE
Only build and test if Dockerfile changed

### DIFF
--- a/.github/workflows/test-image-lintonly.yml
+++ b/.github/workflows/test-image-lintonly.yml
@@ -1,4 +1,4 @@
-name: Lint, build and test
+name: Lint Only
 
 on:
   pull_request:

--- a/.github/workflows/test-image-lintonly.yml
+++ b/.github/workflows/test-image-lintonly.yml
@@ -1,0 +1,41 @@
+name: Lint, build and test
+
+on:
+  pull_request:
+    branches:
+    - main
+    paths-ignore:
+    - Dockerfile
+  push:
+    branches:
+    - main
+    paths-ignore:
+    - Dockerfile
+
+jobs:
+  lint-dockerfile:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Lint Dockerfile
+      uses: ghe-actions/dockerfile-validator@v1
+      with:
+        dockerfile: 'Dockerfile'
+  
+  lint-shellscripts:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Run ShellCheck
+      uses: azohra/shell-linter@latest
+      with:
+        path: "scripts/*.sh"
+  
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: No build or test required
+      run: echo No build or test required
+    

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
     - main
+    paths-ignore:
+    - '!Dockerfile'
   push:
     branches:
     - main
+    paths-ignore:
+    - '!Dockerfile'
 
 jobs:
   lint-dockerfile:


### PR DESCRIPTION
Similar to the limitations to deployment, the "Build and Test" step of the test workflow only needs to run if the Dockerfile has been changed. Linting always happens, since it's fast.