### PR TITLE
Deploy readme to dockerhub

### DIFF
--- a/.github/workflows/deploy-readme.yml
+++ b/.github/workflows/deploy-readme.yml
@@ -1,0 +1,21 @@
+name: Deploy README.md to Dockerhub
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'README.md'
+
+jobs:
+  deploy-readme:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Push readme to dockerhub
+      uses: peter-evans/dockerhub-description@v3
+      with:
+        username: ${{ secrets.dockerhub_login }}
+        password: ${{ secrets.dockerhub_pass }}
+        repository: jreher/boss


### PR DESCRIPTION
Now that the readme on github and dockerhub are identical, this workflow can publish any changes to README.md automatically.