### PR TITLE
Scripts use repo-version of container.

### DIFF
--- a/scripts/initboss.sh
+++ b/scripts/initboss.sh
@@ -3,4 +3,4 @@
 fullpath=$(pwd)
 mount=${fullpath%Yapp*}
 
-docker run --rm -dt --security-opt label=disable -v "$mount":/root/workarea --name bosscontainer --init --privileged boss
+docker run --rm -dt --security-opt label=disable -v "$mount":/root/workarea --name bosscontainer --init --privileged jreher/boss

--- a/scripts/interactiveboss.sh
+++ b/scripts/interactiveboss.sh
@@ -5,4 +5,4 @@ mount=${fullpath%workarea*}
 subpath=${fullpath#*workarea}
 cdpath="/root/workarea/Yapp$subpath"
 
-docker run --security-opt label=disable -it --rm -v "$mount":/root/workarea --workdir "$cdpath" --privileged boss
+docker run --security-opt label=disable -it --rm -v "$mount":/root/workarea --workdir "$cdpath" --privileged jreher/boss


### PR DESCRIPTION
Adjusted scripts/initboss.sh and scripts/interactiveboss.sh to use
`jreher/boss` instead of just boss, meaning that it will be pulled from
dockerhub automatically. Should also prevent mixups should users
experiment with their own version: Scripts always launch mine.