### PR TITLE
Define protected branches for VS code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "git.branchProtection": [
+        "main"
+    ]
+}


### PR DESCRIPTION
VS code can warn users about accidentally pushing to protected branches. I'll include the corresponding configuration in the repo for convenience.