### PR TITLE
Only trigger deploy-all-versions.yml from master

### DIFF
--- a/.github/workflows/deploy-all-versions.yml
+++ b/.github/workflows/deploy-all-versions.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Deploy .tar.gz files","Deploy Image -- Latest"]
     types:
       - completed
+    branches: ["main"]
   workflow_dispatch:
     inputs:
       deploy-all:


### PR DESCRIPTION
Quick patch to ensure the workflow_run trigger only runs on the main
branch, and not if `deploy-tarfiles.yml` is triggered manually for
test purposes (which, admittedly, should be rare since it does affect
the production environment).