### PR TITLE
93 Use GitHub container registry

### DIFF
--- a/.github/workflows/deploy-all-versions.yml
+++ b/.github/workflows/deploy-all-versions.yml
@@ -64,6 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: list-versions
     if: ${{ needs.list-versions.outputs.nver > 0 }}
+    permissions:
+      packages: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +81,12 @@ jobs:
       with:
         username: ${{ secrets.dockerhub_login }}
         password: ${{ secrets.dockerhub_pass }}
+    - name: Login to Docker CR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push image
       uses: docker/build-push-action@v2
       with:
@@ -90,3 +99,4 @@ jobs:
           BOSS_VERSION=${{ matrix.bossversion }}
         tags: |
           jreher/boss:${{ matrix.bossversion }}
+          ghcr.io/${{ github.repository_owner }}/boss:${{ matrix.bossversion }}

--- a/.github/workflows/deploy-all-versions.yml
+++ b/.github/workflows/deploy-all-versions.yml
@@ -64,9 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: list-versions
     if: ${{ needs.list-versions.outputs.nver > 0 }}
-    permissions:
-      packages: write
-      contents: read
+    # permissions:
+    #   packages: write
+    #   contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -81,12 +81,12 @@ jobs:
       with:
         username: ${{ secrets.dockerhub_login }}
         password: ${{ secrets.dockerhub_pass }}
-    - name: Login to Docker CR
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Login to Docker CR
+    #   uses: docker/login-action@v2
+    #   with:
+    #     registry: ghcr.io
+    #     username: ${{ github.actor }}
+    #     password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push image
       uses: docker/build-push-action@v2
       with:
@@ -99,4 +99,4 @@ jobs:
           BOSS_VERSION=${{ matrix.bossversion }}
         tags: |
           jreher/boss:${{ matrix.bossversion }}
-          ghcr.io/${{ github.repository_owner }}/boss:${{ matrix.bossversion }}
+        #  ghcr.io/${{ github.repository_owner }}/boss:${{ matrix.bossversion }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -43,16 +43,6 @@ jobs:
         tags: |
           jreher/boss:utils-base
           ghcr.io/${{ github.repository_owner }}/boss:utils-base
-    - name: Build and push main
-      uses: docker/build-push-action@v2
-      with:
-        context: bossdocker
-        push: true
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        tags: |
-          jreher/boss:latest
-          ghcr.io/${{ github.repository_owner }}/boss:latest
     - name: Build and push install
       uses: docker/build-push-action@v2
       with:
@@ -73,3 +63,14 @@ jobs:
         tags: |
           jreher/boss:utils-cache
           ghcr.io/${{ github.repository_owner }}/boss:utils-cache
+    - name: Build and push main
+      uses: docker/build-push-action@v2
+      with:
+        context: bossdocker
+        push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        tags: |
+          jreher/boss:latest
+          ghcr.io/${{ github.repository_owner }}/boss:latest
+          

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -24,6 +24,12 @@ jobs:
       with:
         username: ${{ secrets.dockerhub_login }}
         password: ${{ secrets.dockerhub_pass }}
+    - name: Login to Docker CR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push base
       uses: docker/build-push-action@v2
       with:
@@ -33,6 +39,7 @@ jobs:
         cache-to: type=gha,mode=max
         tags: |
           jreher/boss:utils-base
+          ghcr.io/${{ github.repository_owner }}/boss:utils-base
     - name: Build and push main
       uses: docker/build-push-action@v2
       with:
@@ -42,6 +49,7 @@ jobs:
         cache-to: type=gha,mode=max
         tags: |
           jreher/boss:latest
+          ghcr.io/${{ github.repository_owner }}/boss:latest
     - name: Build and push install
       uses: docker/build-push-action@v2
       with:
@@ -51,6 +59,7 @@ jobs:
         cache-to: type=gha,mode=max
         tags: |
           jreher/boss:utils-install
+          ghcr.io/${{ github.repository_owner }}/boss:utils-install
     - name: Build and push installcache
       uses: docker/build-push-action@v2
       with:
@@ -60,3 +69,4 @@ jobs:
         cache-to: type=gha,mode=max
         tags: |
           jreher/boss:utils-cache
+          ghcr.io/${{ github.repository_owner }}/boss:utils-cache

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -19,17 +19,17 @@ jobs:
       uses: actions/checkout@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.dockerhub_login }}
-        password: ${{ secrets.dockerhub_pass }}
     - name: Login to Docker CR
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.dockerhub_login }}
+        password: ${{ secrets.dockerhub_pass }}
     - name: Build and push base
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Extended deploy scripts to push to GitHub container registry in addition to DockerHub.
I don't know if that is ever going to be used, but it's right there, so #whynot.