### PR TITLE
Fixed boss installation for newer boss versions

### DIFF
--- a/bossdocker-installboss/bossmaker.sh
+++ b/bossdocker-installboss/bossmaker.sh
@@ -17,7 +17,7 @@ compathome=$cmthome-Slc6Centos7Compat
 printf '\nCopy %s to cmthome\n' "$cmthome"
 cp -r "$cmthome"/* /root/cmthome/
 printf "\nMake Adjustments to cmthome/requirements\n"
-sed -i 's/#macro WorkArea \"\/home\/bes\/maqm\/workarea\"/macro WorkArea \"\/root\/workarea\"/g' /root/cmthome/requirements
+sed -i 's@#macro WorkArea.*@macro WorkArea "/root/workarea"@' /root/cmthome/requirements
 sed -i 's/#path_remove/path_remove/g' /root/cmthome/requirements
 sed -i 's/#path_prepend/path_prepend/g' /root/cmthome/requirements
 printf "\nConfigure CMT\n"


### PR DESCRIPTION
Boss 7.0.9.p01 had problems compiling analysis code because the workarea was not in CMTPATH, indicating an issue with the boss installation.

Investigation showed that the original content of a line in `cmthome/requirements` that is replaced by the install scripts changed, so the `sed` command making the replacement didn't recognize it anymore. Consequently, the line was not replaced, and the workara was unknown for those versions.

I adjusted the install script to be more inclusive, it should now recognize any (valid) version of that line and plop in the correct workarea properly.