### PR TITLE
Fix deploy-tarfiles.yml

### DIFF
--- a/.github/workflows/deploy-tarfiles.yml
+++ b/.github/workflows/deploy-tarfiles.yml
@@ -32,9 +32,9 @@ jobs:
         touch versions_processed.txt
         while IFS="" read -r p || [ -n "$p" ]
         do
-          if ! curl --head --silent --fail "https://ep1.rub.de/~jreher/bossdocker-download/cmthome/cmthome-${{ matrix.bossversion }}.tar.gz" 2> /dev/null && \
-          curl --head --silent --fail "https://ep1.rub.de/~jreher/bossdocker-download/cache/cvmfs-cache-${{ matrix.bossversion }}.tar.gz" 2> /dev/null && \
-          curl --head --silent --fail "https://ep1.rub.de/~jreher/bossdocker-download/testrelease/TestRelease-${{ matrix.bossversion }}.tar.gz" 2> /dev/null ; then
+          if ! curl --head --silent --fail "https://ep1.rub.de/~jreher/bossdocker-download/cmthome/cmthome-$p.tar.gz" 2> /dev/null && \
+          curl --head --silent --fail "https://ep1.rub.de/~jreher/bossdocker-download/cache/cvmfs-cache-$p.tar.gz" 2> /dev/null && \
+          curl --head --silent --fail "https://ep1.rub.de/~jreher/bossdocker-download/testrelease/TestRelease-$p.tar.gz" 2> /dev/null ; then
             echo "Staging files for version $p for upload."
             echo "$p" >> versions_processed.txt
           fi


### PR DESCRIPTION
The part of `deploy-tarfiles.yml` that was supposed to identify missing versions did not work, using the job matrix that was not yet created (and therefore probably empty) for the boss version to check. Fixed that.