### PR TITLE
Make "deploy latest" update containers

### DIFF
--- a/.github/workflows/deploy-all-versions.yml
+++ b/.github/workflows/deploy-all-versions.yml
@@ -15,7 +15,7 @@ on:
         description: Remake all images instead of only the missing ones.
 
 env:
-  DEPLOY_ALL: ${{ ( github.event_name == 'workflow_run' && github.event.workflow == 'Deploy Image -- Latest' ) || ( github.event_name == 'workflow_dispatch' && github.event.inputs.deploy-all == 'true' ) }}
+  DEPLOY_ALL: ${{ ( github.event_name == 'workflow_run' && github.event.workflow.name == 'Deploy Image -- Latest' ) || ( github.event_name == 'workflow_dispatch' && github.event.inputs.deploy-all == 'true' ) }}
 
 jobs:
   echo-caller:


### PR DESCRIPTION
There was an issue with "Deploy all versions" that caused it to not recognize the "Deploy Latest" workflow. I think I've got that fixed now.