### PR TITLE
Username as part of container and volume names

### DIFF
--- a/scripts-podman/boss.exe.sh
+++ b/scripts-podman/boss.exe.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-if ! podman container inspect bosscontainer >& /dev/null ; then
+CONTAINERNAME="bosscontainer-$(id -un)"
+
+if ! podman container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "Boss container is not running!"
     exit 1
 fi
 
-VOLUMESTRING="$(podman inspect -f '{{ .Mounts }}' bosscontainer)"
+VOLUMESTRING="$(podman inspect -f '{{ .Mounts }}' $CONTAINERNAME)"
 TEMPSTRING1=${VOLUMESTRING#*\{bind}
 TEMPSTRING2=${TEMPSTRING1%/root*}
 WORKAREA="$(echo "$TEMPSTRING2" | awk '{$1=$1}1')"
@@ -25,4 +27,4 @@ fi
 
 CDPATH="/root/workarea/$SUBDIR"
 
-podman exec --workdir "$CDPATH" bosscontainer bash -c "source /root/setup.sh && boss.exe $*"
+podman exec --workdir "$CDPATH" "$CONTAINERNAME" bash -c "source /root/setup.sh && boss.exe $*"

--- a/scripts-podman/boss_shell.sh
+++ b/scripts-podman/boss_shell.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-if ! podman container inspect bosscontainer >& /dev/null ; then
+CONTAINERNAME="bosscontainer-$(id -un)"
+
+if ! podman container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "Boss container is not running!"
     exit 1
 fi
 
 CDPATH="/root/workarea"
 
-VOLUMESTRING="$(podman inspect -f '{{ .Mounts }}' bosscontainer)"
+VOLUMESTRING="$(podman inspect -f '{{ .Mounts }}' $CONTAINERNAME)"
 TEMPSTRING1=${VOLUMESTRING#*\{bind}
 TEMPSTRING2=${TEMPSTRING1%/root*}
 WORKAREA="$(echo "$TEMPSTRING2" | awk '{$1=$1}1')"
@@ -20,4 +22,4 @@ if [ -d "$WORKAREA" ] ; then
     fi
 fi
 
-podman exec -it --workdir "$CDPATH" bosscontainer bash
+podman exec -it --workdir "$CDPATH" "$CONTAINERNAME" bash

--- a/scripts-podman/cmt.sh
+++ b/scripts-podman/cmt.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-if ! podman container inspect bosscontainer >& /dev/null ; then
+CONTAINERNAME="bosscontainer-$(id -un)"
+
+if ! podman container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "Boss container is not running!"
     exit 1
 fi
 
-VOLUMESTRING="$(podman inspect -f '{{ .Mounts }}' bosscontainer)"
+VOLUMESTRING="$(podman inspect -f '{{ .Mounts }}' $CONTAINERNAME)"
 TEMPSTRING1=${VOLUMESTRING#*\{bind}
 TEMPSTRING2=${TEMPSTRING1%/root*}
 WORKAREA="$(echo "$TEMPSTRING2" | awk '{$1=$1}1')"
@@ -25,4 +27,4 @@ fi
 
 CDPATH="/root/workarea/$SUBDIR"
 
-podman exec --workdir "$CDPATH" bosscontainer bash -c "source /root/setup.sh && cmt $*"
+podman exec --workdir "$CDPATH" "$CONTAINERNAME" bash -c "source /root/setup.sh && cmt $*"

--- a/scripts-podman/initboss.sh
+++ b/scripts-podman/initboss.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CONTAINERNAME="bosscontainer-$(id -un)"
+
 # Default values:
 # Default values:
 FULLPATH=$(pwd)
@@ -55,7 +57,7 @@ do
     esac
 done
 
-if podman container inspect bosscontainer >& /dev/null ; then
+if podman container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "A boss container is already running! Please stop it before starting another."
     exit 1
 fi
@@ -68,7 +70,7 @@ export WORKAREA
 
 CACHEARG=""
 if [ $PERSISTCACHE == 1 ] ; then
-    CACHEARG="-v cvmfs_cache_$CONTAINER_VERSION:/var/cvmfs/cache "
-    podman volume inspect "cvmfs_cache_$CONTAINER_VERSION" >& /dev/null || echo "Creating cvmfs-cache volume for Version $CONTAINER_VERSION. BOSS might be slow while it's being populated!"
+    CACHEARG="-v cvmfs_cache_$(id -un)_$CONTAINER_VERSION:/var/cvmfs/cache "
+    podman volume inspect "cvmfs_cache_$(id -un)_$CONTAINER_VERSION" >& /dev/null || echo "Creating cvmfs-cache volume for Version $CONTAINER_VERSION. BOSS might be slow while it's being populated!"
 fi
-podman run --rm -dt --security-opt label=disable ${CACHEARG}-v "$WORKAREA":/root/workarea --name bosscontainer --init --privileged "${REPOSITORY}jreher/boss:$CONTAINER_VERSION" 1>/dev/null
+podman run --rm -dt --security-opt label=disable ${CACHEARG}-v "$WORKAREA":/root/workarea --name "$CONTAINERNAME" --init --privileged "${REPOSITORY}jreher/boss:$CONTAINER_VERSION" 1>/dev/null

--- a/scripts-podman/interactiveboss.sh
+++ b/scripts-podman/interactiveboss.sh
@@ -53,7 +53,7 @@ do
     esac
 done
 
-if podman container inspect bosscontainer >& /dev/null ; then
+if podman container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "A boss container is already running! Please stop it before starting another."
     exit 1
 fi

--- a/scripts-podman/stopboss.sh
+++ b/scripts-podman/stopboss.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CONTAINERNAME="bosscontainer-$(id -un)"
+
 CLEARCACHES=0
 
 SHORT=h
@@ -31,11 +33,11 @@ do
     esac
 done
 
-if podman container inspect bosscontainer >& /dev/null ; then
-podman stop bosscontainer >& /dev/null && echo "Boss container was stopped successfully."
+if podman container inspect "$CONTAINERNAME" >& /dev/null ; then
+podman stop "$CONTAINERNAME" >& /dev/null && echo "Boss container was stopped successfully."
 fi
 
-VOLUMES=$(podman volume ls -qf name=cvmfs_cache_)
+VOLUMES=$(podman volume ls -qf name="cvmfs_cache_$(id -un)_")
 if [ $CLEARCACHES == 1 ] && [ "$VOLUMES" != "" ] ; then
     podman volume rm $VOLUMES >& /dev/null && printf 'Removed the following CVMFS cache volumes:\n%-s\n' "$VOLUMES"
 fi

--- a/scripts/boss.exe.sh
+++ b/scripts/boss.exe.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-if ! docker container inspect bosscontainer >& /dev/null ; then
+CONTAINERNAME="bosscontainer-$(id -un)"
+
+if ! docker container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "Boss container is not running!"
     exit 1
 fi
 
-VOLUMESTRING="$(docker inspect -f '{{ .Mounts }}' bosscontainer)"
+VOLUMESTRING="$(docker inspect -f '{{ .Mounts }}' $CONTAINERNAME)"
 TEMPSTRING1=${VOLUMESTRING#*bind}
 TEMPSTRING2=${TEMPSTRING1%/root*}
 WORKAREA="$(echo "$TEMPSTRING2" | awk '{$1=$1}1')"
@@ -25,4 +27,4 @@ fi
 
 CDPATH="/root/workarea/$SUBDIR"
 
-docker exec --workdir "$CDPATH" bosscontainer bash -c "source /root/setup.sh && boss.exe $* ; chown -R $(id -u):$(id -g) $CDPATH"
+docker exec --workdir "$CDPATH" "$CONTAINERNAME" bash -c "source /root/setup.sh && boss.exe $* ; chown -R $(id -u):$(id -g) $CDPATH"

--- a/scripts/boss_shell.sh
+++ b/scripts/boss_shell.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-if ! docker container inspect bosscontainer >& /dev/null ; then
+CONTAINERNAME="bosscontainer-$(id -un)"
+
+if ! docker container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "Boss container is not running!"
     exit 1
 fi
 
 CDPATH="/root/workarea"
 
-VOLUMESTRING="$(docker inspect -f '{{ .Mounts }}' bosscontainer)"
+VOLUMESTRING="$(docker inspect -f '{{ .Mounts }}' $CONTAINERNAME)"
 TEMPSTRING1=${VOLUMESTRING#*bind}
 TEMPSTRING2=${TEMPSTRING1%/root*}
 WORKAREA="$(echo "$TEMPSTRING2" | awk '{$1=$1}1')"
@@ -20,4 +22,4 @@ if [ -d "$WORKAREA" ] ; then
     fi
 fi
 
-docker exec -it --workdir "$CDPATH" bosscontainer bash
+docker exec -it --workdir "$CDPATH" "$CONTAINERNAME" bash

--- a/scripts/cmt.sh
+++ b/scripts/cmt.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-if ! docker container inspect bosscontainer >& /dev/null ; then
+CONTAINERNAME="bosscontainer-$(id -un)"
+
+if ! docker container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "Boss container is not running!"
     exit 1
 fi
 
-VOLUMESTRING="$(docker inspect -f '{{ .Mounts }}' bosscontainer)"
+VOLUMESTRING="$(docker inspect -f '{{ .Mounts }}' $CONTAINERNAME)"
 TEMPSTRING1=${VOLUMESTRING#*bind}
 TEMPSTRING2=${TEMPSTRING1%/root*}
 WORKAREA="$(echo "$TEMPSTRING2" | awk '{$1=$1}1')"
@@ -25,4 +27,4 @@ fi
 
 CDPATH="/root/workarea/$SUBDIR"
 
-docker exec --workdir "$CDPATH" bosscontainer bash -c "source /root/setup.sh && cmt $* ; chown -R $(id -u):$(id -g) /root/workarea"
+docker exec --workdir "$CDPATH" "$CONTAINERNAME" bash -c "source /root/setup.sh && cmt $* ; chown -R $(id -u):$(id -g) /root/workarea"

--- a/scripts/interactiveboss.sh
+++ b/scripts/interactiveboss.sh
@@ -53,7 +53,7 @@ do
     esac
 done
 
-if docker container inspect bosscontainer >& /dev/null ; then
+if docker container inspect "$CONTAINERNAME" >& /dev/null ; then
     echo "A boss container is already running! Please stop it before starting another."
     exit 1
 fi

--- a/scripts/stopboss.sh
+++ b/scripts/stopboss.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CONTAINERNAME="bosscontainer-$(id -un)"
+
 CLEARCACHES=0
 
 SHORT=h
@@ -31,11 +33,11 @@ do
     esac
 done
 
-if docker container inspect bosscontainer >& /dev/null ; then
-docker stop bosscontainer >& /dev/null && echo "Boss container was stopped successfully."
+if docker container inspect "$CONTAINERNAME" >& /dev/null ; then
+docker stop "$CONTAINERNAME" >& /dev/null && echo "Boss container was stopped successfully."
 fi
 
-VOLUMES=$(docker volume ls -qf name=cvmfs_cache_)
+VOLUMES=$(docker volume ls -qf name="cvmfs_cache_$(id -un)_")
 if [ $CLEARCACHES == 1 ] && [ "$VOLUMES" != "" ] ; then
     docker volume rm $VOLUMES >& /dev/null && printf 'Removed the following CVMFS cache volumes:\n%-s\n' "$VOLUMES"
 fi


### PR DESCRIPTION
Updeated the shell scripts to include `-$(id -un)` in the container and volume names to avoid issues with multiple users on the same machine.

Also see Issue #113.