### PR TITLE
Automatically get TestRelease if missing

### DIFF
--- a/.github/workflows/test-image-lintonly.yml
+++ b/.github/workflows/test-image-lintonly.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: ghe-actions/dockerfile-validator@v1
+      uses: ghe-actions/dockerfile-validator@v2
       with:
         dockerfile: 'Dockerfile'
 
@@ -35,7 +35,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: ghe-actions/dockerfile-validator@v1
+      uses: ghe-actions/dockerfile-validator@v2
       with:
         dockerfile: 'bossdocker-base/Dockerfile'
 
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: ghe-actions/dockerfile-validator@v1
+      uses: ghe-actions/dockerfile-validator@v2
       with:
         dockerfile: 'bossdocker-installboss/Dockerfile'
 
@@ -55,7 +55,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: ghe-actions/dockerfile-validator@v1
+      uses: ghe-actions/dockerfile-validator@v2
       with:
         dockerfile: 'bossdocker-installboss-cache/Dockerfile'
   

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: ghe-actions/dockerfile-validator@v1
+      uses: ghe-actions/dockerfile-validator@v2
       with:
         dockerfile: 'Dockerfile'
 
@@ -41,7 +41,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: ghe-actions/dockerfile-validator@v1
+      uses: ghe-actions/dockerfile-validator@v2
       with:
         dockerfile: 'bossdocker-base/Dockerfile'
 
@@ -51,7 +51,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: ghe-actions/dockerfile-validator@v1
+      uses: ghe-actions/dockerfile-validator@v2
       with:
         dockerfile: 'bossdocker-installboss/Dockerfile'
 
@@ -61,7 +61,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: ghe-actions/dockerfile-validator@v1
+      uses: ghe-actions/dockerfile-validator@v2
       with:
         dockerfile: 'bossdocker-installboss-cache/Dockerfile'
   

--- a/scripts/initboss.sh
+++ b/scripts/initboss.sh
@@ -73,3 +73,4 @@ if [ $PERSISTCACHE == 1 ] ; then
 fi
 
 docker run --rm -dt --security-opt label=disable ${CACHEARG}-v "$WORKAREA":/root/workarea --name "$CONTAINERNAME" --init --privileged "${REPOSITORY}jreher/boss:$CONTAINER_VERSION" 1>/dev/null
+docker exec "$CONTAINERNAME" chown -R "$(id -u)":"$(id -g)" /root/workarea/


### PR DESCRIPTION
As mentioned in issue #135, test TestRelease missing in an empty WorkArea can be quite inconvenient.
Now, the container will check if the correct version of TestRelease for its BOSS version is present in the workarea, and if not, it is copied in there. This happens before even mounting the cvmfs directories, as part of `dockerinit.sh`.