### PR TITLE
Avoid endless echos in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,5 @@
-.github
-.vscode
-bossdocker-base
-bossdocker-installboss
-bossdocker-installboss-cache
-output
-scripts
-scripts-postman
-testing
-workarea
-.gitignore
-LICENSE
-README.md
-versions.txt
+# Ignore everything
+*
+
+# Allow specific files:
+!inputs/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,18 +25,12 @@ RUN yum -y install libXpm-devel libXi-devel && \
     yum -y clean all && \
     rm -rf /var/cache/yum
 
+ADD inputs/dockerinit.sh /root/dockerinit.sh
+ADD inputs/setup.sh /root/setup.sh
+ADD inputs/mount.sh /root/mount.sh
+
 RUN cp /root/workarea/TestRelease/TestRelease-*/cmt/setup.sh setupTestRelease.sh && \
-    echo "source /root/cmthome/setupCMT.sh" >> /root/setup.sh && \
-    echo "source /root/cmthome/setup.sh" >> /root/setup.sh && \
-    echo "source /root/setupTestRelease.sh" >> /root/setup.sh && \
-    echo "export WORKAREA=/root/workarea" >> /root/setup.sh && \
-    echo "if [ ! -n \"\$(ls -A /cvmfs/bes3.ihep.ac.cn 2>/dev/null)\" ] ; then" >> /root/mount.sh && \
-    echo "    mount -a" >> /root/mount.sh && \
-    echo "fi" >> /root/mount.sh && \
-    echo "#!/bin/bash" >> /root/dockerinit.sh && \
-    echo "source /root/mount.sh" >> /root/dockerinit.sh && \
-    echo "source /root/setup.sh" >> /root/dockerinit.sh && \
-    echo "bash -i" >> /root/dockerinit.sh && \
+    cp -r /root/workarea/TestRelease/ /root/TestRelease && \
     chmod u+x /root/dockerinit.sh && \
     # echo "    source /root/mount.sh" >> /root/.bashrc && \
     # echo "    source /root/setup.sh" >> /root/.bashrc && \

--- a/inputs/dockerinit.sh
+++ b/inputs/dockerinit.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-TestReleaseName="$(find /root/TestRelease/TestRelease-* -maxdepth 0 -type d)"
-if [ ! -d "/root/workarea/TestRelease/$TestReleaseName" ]; then
-  echo "$TestReleaseName not found in workarea! Copying from Template..."
-  mkdir -p /root/workarea/TestRelease
-  cp -r /root/TestRelease/* /root/workarea/TestRelease/
-fi
 source /root/mount.sh
 source /root/setup.sh
 bash -i

--- a/inputs/dockerinit.sh
+++ b/inputs/dockerinit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+TestReleaseName="$(find /root/TestRelease/TestRelease-* -maxdepth 0 -type d)"
+if [ ! -d "/root/workarea/TestRelease/$TestReleaseName" ]; then
+  echo "$TestReleaseName not found in workarea! Copying from Template..."
+  mkdir -p /root/workarea/TestRelease
+  cp -r /root/TestRelease/* /root/workarea/TestRelease/
+fi
+source /root/mount.sh
+source /root/setup.sh
+bash -i

--- a/inputs/mount.sh
+++ b/inputs/mount.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -z "$(ls -A /cvmfs/bes3.ihep.ac.cn 2>/dev/null)" ] ; then
+  mount -a
+fi

--- a/inputs/setup.sh
+++ b/inputs/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source /root/cmthome/setupCMT.sh
+source /root/cmthome/setup.sh
+source /root/setupTestRelease.sh
+export WORKAREA=/root/workarea


### PR DESCRIPTION
Using `RUN echo "whatever" >> script.sh` in the Dockerfile has gotten out of hand and become hard to maintain.
Instead, relevant scripts are now located in `includes/` and added to the container using `ADD` commands.