### PR TITLE
Implemented automatic copying of TestRelease

### DIFF
--- a/inputs/dockerinit.sh
+++ b/inputs/dockerinit.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+TestReleaseName="$(find /root/TestRelease/TestRelease-* -maxdepth 0 -type d)"
+if [ ! -d "/root/workarea/TestRelease/$TestReleaseName" ]; then
+  echo "$TestReleaseName not found in workarea! Copying from Template..."
+  mkdir -p /root/workarea/TestRelease
+  cp -r /root/TestRelease/* /root/workarea/TestRelease/
+fi
 source /root/mount.sh
 source /root/setup.sh
 bash -i

--- a/scripts/initboss.sh
+++ b/scripts/initboss.sh
@@ -73,3 +73,4 @@ if [ $PERSISTCACHE == 1 ] ; then
 fi
 
 docker run --rm -dt --security-opt label=disable ${CACHEARG}-v "$WORKAREA":/root/workarea --name "$CONTAINERNAME" --init --privileged "${REPOSITORY}jreher/boss:$CONTAINER_VERSION" 1>/dev/null
+docker exec "$CONTAINERNAME" chown -R "$(id -u)":"$(id -g)" /root/workarea/


### PR DESCRIPTION
As mentioned in issue https://github.com/j-reher/bossdocker/issues/135, test TestRelease missing in an empty WorkArea can be quite inconvenient.
Now, the container will check if the correct version of TestRelease for its BOSS version is present in the workarea, and if not, it is copied in there. This happens before even mounting the cvmfs directories, as part of dockerinit.sh.